### PR TITLE
Bugfix/double begin block in create triggers script

### DIFF
--- a/Api/Core/Queries/WiserInstallation/CreateTriggers.sql
+++ b/Api/Core/Queries/WiserInstallation/CreateTriggers.sql
@@ -642,7 +642,6 @@ END;
 
 DROP TRIGGER IF EXISTS `DetailUpdate`;
 CREATE TRIGGER `DetailUpdate` AFTER UPDATE ON `wiser_itemdetail` FOR EACH ROW BEGIN
-BEGIN
     DECLARE oldValue MEDIUMTEXT;
     DECLARE newValue MEDIUMTEXT;
     DECLARE previousItemId BIGINT;


### PR DESCRIPTION
This issue occurred when running the MySQL setup command (in the CreateTriggers.sql script)