### PR TITLE
Feature/extra data in post query for api call action

### DIFF
--- a/FrontEnd/Modules/Base/Scripts/Utils.js
+++ b/FrontEnd/Modules/Base/Scripts/Utils.js
@@ -793,13 +793,24 @@ export class Wiser {
                             }
                             break;
                     }
+                    
+                    let postQueryData = apiResults;
+                    
+                    const appendDataWithApiResults = action.appendDataWithApiResults ?? false;
+                    if(appendDataWithApiResults) {
+                        postQueryData = {};
+                        postQueryData['response'] = apiResults;
+                        postQueryData['data'] = extraData;
+
+                        postQueryData = Misc.flattenObject(postQueryData);
+                    }
 
                     // If a postRequestQueryId is set, execute that query after the API call, so that the results of the API call can be used in the query.
                     if (action.postRequestQueryId && itemDetails) {
                         const postRequestQueryResult = await Wiser.api({
                             method: "POST",
                             url: `${settings.wiserApiRoot}items/${encodeURIComponent(itemDetails.encryptedId || itemDetails.encrypted_id || itemDetails.encryptedid)}/action-button/0?queryId=${encodeURIComponent(action.postRequestQueryId)}&itemLinkId=${encodeURIComponent(itemDetails.linkId || itemDetails.link_id || 0)}`,
-                            data: !apiResults ? null : JSON.stringify(apiResults),
+                            data: !postQueryData ? null : JSON.stringify(postQueryData),
                             contentType: "application/json"
                         });
                     }

--- a/FrontEnd/Modules/Base/Scripts/Utils.js
+++ b/FrontEnd/Modules/Base/Scripts/Utils.js
@@ -1638,18 +1638,38 @@ export class Misc {
             }
         });
     }
-    
+
+    /**
+     * Flattens an object with a finite amount of nested objects into a one-dimensional object. The keys of all
+     * properties will be transformed by prefixing them with the path leading to the original property separated by a
+     * period.
+     * @param originalRootObject The object to flatten.
+     * @param writeRootObject (Internal) used during recursion to refer back to the object to flatten.
+     * @param currentPath (Internal) used during recursion to keep track of the current path leading to the object that
+     * is being flattened.
+     * @returns {{Object}} A copy of the given object represented in a flattened state.
+     */
     static flattenObject(originalRootObject, writeRootObject = {}, currentPath = null) {
+        // Get the current path in the recursion as segments in an array.
         const pathSegments = currentPath !== null ? currentPath.split('.') : [];
+        // Get the current object in the recursion given by the path.
         let currentObject = originalRootObject;
         for(let pathSegment of pathSegments)
             currentObject = currentObject[pathSegment];
-        
+
+        // List all property names.
         const keys = Object.keys(currentObject);
+        // Loop through all properties in the current object of the recursion.
         for(let key of keys) {
+            // Get the absolute path of the property.
             const propertyPath = (currentPath !== null ? currentPath + "." : '') + key;
             
+            // Get the value of the property.
             const propertyValue = currentObject[key];
+            
+            // Check whether the property is an object. If so, perform a new recursion iteration over this object.
+            // Otherwise, flatten the property by saving its value and path (as key) to the object that will be
+            // returned.
             if(propertyValue instanceof Object && !Array.isArray(propertyValue)) {
                 writeRootObject = this.flattenObject(originalRootObject, writeRootObject, propertyPath);
             } else {
@@ -1657,6 +1677,8 @@ export class Misc {
             }
         }
         
+        // Give back the object in it's current state.
+        // Returning is necessary, since adding new properties to objects is not by reference, but by value.
         return writeRootObject;
     }
 }

--- a/FrontEnd/Modules/Base/Scripts/Utils.js
+++ b/FrontEnd/Modules/Base/Scripts/Utils.js
@@ -1627,6 +1627,27 @@ export class Misc {
             }
         });
     }
+    
+    static flattenObject(originalRootObject, writeRootObject = {}, currentPath = null) {
+        const pathSegments = currentPath !== null ? currentPath.split('.') : [];
+        let currentObject = originalRootObject;
+        for(let pathSegment of pathSegments)
+            currentObject = currentObject[pathSegment];
+        
+        const keys = Object.keys(currentObject);
+        for(let key of keys) {
+            const propertyPath = (currentPath !== null ? currentPath + "." : '') + key;
+            
+            const propertyValue = currentObject[key];
+            if(propertyValue instanceof Object && !Array.isArray(propertyValue)) {
+                writeRootObject = this.flattenObject(originalRootObject, writeRootObject, propertyPath);
+            } else {
+                writeRootObject[propertyPath] = propertyValue;
+            }
+        }
+        
+        return writeRootObject;
+    }
 }
 
 // Make the classes globally available, so that they also work in scripts that are not loaded via Webpack.

--- a/FrontEnd/Modules/DynamicItems/Scripts/Fields.js
+++ b/FrontEnd/Modules/DynamicItems/Scripts/Fields.js
@@ -66,6 +66,7 @@ export class Fields {
             const data = {
                 key: fieldName,
                 itemLinkId: parseInt(fieldData.itemLinkId) || 0,
+                linkType: parseInt(fieldData.linkType) || 0,
                 languageCode: fieldData.languageCode || ""
             };
 


### PR DESCRIPTION
# Describe your changes

This feature brings an additional setting for `api_call` actions. Before, the only replaceable data that could be used in a post-query for this type of action, was the data from the response of the API call. Only the pre-query had the ability to use data from the provided `extraData` object in the action. For this reason, a new attribute is introduced, named `appendDataWithApiResults`. Including this attribute in the API call's settings and setting it to `true` will include the `extraData` object besides the response data from the request's response. This will allow the user to both use data from the API's response _and_ the data from the `extraData` object.

Here is a quick step-by-step description of what happens when the `appendDataWithApiResults` is included as a flag:

1. The API request is made and a response with data is returned.
2. The response data from the request is put in a new object (named `postQueryData`) with the key `response`.
3. The `extraData` object from the action is put in the same object with the key `data`.
4. The object (`postQueryData`) is flattened. Flattened (in this context) means that all properties within the object will be unnested and put at the root of the object. The key of the property is represented as a path leading to the original property separated by a period (`.`).
5. The object (`postQueryData`) is passed to the post-query to be utilized as usual.

Then, when writing a post-query, the data can be accessed in the following way according to the given example:
Example of `postQueryData` (before being flattened):
```json
{
   "response": {
      "success": true,
      "data": {
         "id": 12,
         "first_name": "John"
         "last_name": "Doe"
      }
   },
   "data": {
      "selected_id": 400176,
      "selected_phone_number": "+31 6 12345678"
   }
}
```
Example of `postQueryData` (flattened):
```json
{
   "response.success": true,
   "response.data.id": 12,
   "response.data.first_name": "John",
   "response.data.last_name": "Doe",
   "data.selected_id": 400176,
   "data.phone_number": "+31 6 12345678"
}
```
Usage in a post-query:
```sql
INSERT INTO `people` (`first_name`, `last_name`, `phone_number`, `reference_id`)
VALUES
('{response.data.first_name}', '{response.data.last_name}', '{data.selected_phone_number}', {data.selected_id})
```

## Type of change

Please check only ONE option.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

To support backward compatibility, we have decided to include the ability to add an optional attribute (`appendDataWithApiResults`) to an API's connection settings. This way all previous API connections will remain behaving the same as they previously did. If you wish to use this new feature, you simply add the attribute to the API's connection settings and implement it in a query the way wish it to work.

This new feature was tested by testing if "old" API actions still work as they are supposed to work. API connections with this new attribute were also tested to include data from the `extraData` object in a post-query. This data was then properly processed and thus replaced by Wiser.

# Checklist before requesting a review
- [x] I have reviewed and tested my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [x] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [x] I added new unit tests for my changes if applicable

The relevant documentation to adjust for this feature is in the Wiki of this project. I can't change that as a change for this pull request.

# Related pull requests

Add any open pull requests from other projects that are related to this pull request that should be merged along with this one. If there are none, you can simply say "none" or "N/A", or just leave this section empty.

# Link to Asana ticket

https://app.asana.com/0/0/1207054476779288/f