### PR TITLE
feature/api-call-action-per-selected-item

### DIFF
--- a/FrontEnd/Modules/DynamicItems/Scripts/Fields.js
+++ b/FrontEnd/Modules/DynamicItems/Scripts/Fields.js
@@ -2273,39 +2273,39 @@ export class Fields {
                         try {
                             // Retrieve the optional attribute whether this action has to be run iteratively.
                             const isIterative = action.iterative ?? false;
+                            const hasItemsSelected = selectedItems && selectedItems.length > 0;
                             
-                            // Check whether any items have been selected.
-                            if(selectedItems && selectedItems.length > 0) {
-                                if(isIterative) {
-                                    // Loop over all of the selected items from the grid.
-                                    for(const selectedItem of selectedItems) {
-                                        const selectedItemData = selectedItem['dataItem'];
-                                        
-                                        // Prepare an object with the data of the currently selected item in the iteration.
-                                        let extraData = {};
-                                        // Loop over all data fields of the currently selected item in the iteration.
-                                        for(const selectedItemKey in selectedItemData) {
-                                            // Exclude data fields if they are irrelevant to the data provided to the API call (objects, functions, etc).
-                                            if (
-                                                !selectedItemData.hasOwnProperty(selectedItemKey) ||
-                                                (typeof selectedItemData[selectedItemKey] === "object" && !(selectedItemData[selectedItemKey] || {}).getDate)) {
-                                                continue;
-                                            }
-                                            
-                                            // Push the data field from the currently selected item in the iteration to the data object.
-                                            const key = `selected_${selectedItemKey}`;
-                                            extraData[key] = selectedItemData[selectedItemKey];
+                            if(isIterative && hasItemsSelected) {
+                                // Loop over all of the selected items from the grid.
+                                for(const selectedItem of selectedItems) {
+                                    const selectedItemData = selectedItem['dataItem'];
+
+                                    // Prepare an object with the data of the currently selected item in the iteration.
+                                    let extraData = {};
+                                    // Loop over all data fields of the currently selected item in the iteration.
+                                    for(const selectedItemKey in selectedItemData) {
+                                        // Exclude data fields if they are irrelevant to the data provided to the API call (objects, functions, etc).
+                                        if (
+                                            !selectedItemData.hasOwnProperty(selectedItemKey) ||
+                                            (typeof selectedItemData[selectedItemKey] === "object" && !(selectedItemData[selectedItemKey] || {}).getDate)) {
+                                            continue;
                                         }
 
-                                        // Make an API call for the currently selected item in the iteration.
-                                        await Wiser.doApiCall(this.base.settings, action.apiConnectionId, mainItemDetails, extraData);
+                                        // Push the data field from the currently selected item in the iteration to the data object.
+                                        const key = `selected_${selectedItemKey}`;
+                                        extraData[key] = selectedItemData[selectedItemKey];
                                     }
-                                } else {
-                                    // Combine all values of the selected items.
-                                    await combineValuesFromAllSelectedItemsAndAddToUserParameters();
-                                    // Make an API call for all selected items.
-                                    await Wiser.doApiCall(this.base.settings, action.apiConnectionId, mainItemDetails, userParametersWithValues);
+
+                                    // Make an API call for the currently selected item in the iteration.
+                                    await Wiser.doApiCall(this.base.settings, action.apiConnectionId, mainItemDetails, extraData);
                                 }
+                            } else {
+                                // Combine all values of the selected items.
+                                if(hasItemsSelected)
+                                    await combineValuesFromAllSelectedItemsAndAddToUserParameters();
+                                
+                                // Make an API call for all selected items.
+                                await Wiser.doApiCall(this.base.settings, action.apiConnectionId, mainItemDetails, userParametersWithValues);
                             }
                         } catch (apiCallException) {
                             if (typeof apiCallException === "string") {

--- a/FrontEnd/Modules/DynamicItems/Scripts/Fields.js
+++ b/FrontEnd/Modules/DynamicItems/Scripts/Fields.js
@@ -2271,29 +2271,39 @@ export class Fields {
                     // Calls an API.
                     case "apiCall": {
                         try {
+                            // Retrieve the optional attribute whether this action has to be run iteratively.
                             const isIterative = action.iterative ?? false;
                             
+                            // Check whether any items have been selected.
                             if(selectedItems && selectedItems.length > 0) {
                                 if(isIterative) {
+                                    // Loop over all of the selected items from the grid.
                                     for(const selectedItem of selectedItems) {
                                         const selectedItemData = selectedItem['dataItem'];
                                         
+                                        // Prepare an object with the data of the currently selected item in the iteration.
                                         let extraData = {};
+                                        // Loop over all data fields of the currently selected item in the iteration.
                                         for(const selectedItemKey in selectedItemData) {
+                                            // Exclude data fields if they are irrelevant to the data provided to the API call (objects, functions, etc).
                                             if (
                                                 !selectedItemData.hasOwnProperty(selectedItemKey) ||
                                                 (typeof selectedItemData[selectedItemKey] === "object" && !(selectedItemData[selectedItemKey] || {}).getDate)) {
                                                 continue;
                                             }
-
+                                            
+                                            // Push the data field from the currently selected item in the iteration to the data object.
                                             const key = `selected_${selectedItemKey}`;
                                             extraData[key] = selectedItemData[selectedItemKey];
                                         }
 
+                                        // Make an API call for the currently selected item in the iteration.
                                         await Wiser.doApiCall(this.base.settings, action.apiConnectionId, mainItemDetails, extraData);
                                     }
                                 } else {
+                                    // Combine all values of the selected items.
                                     await combineValuesFromAllSelectedItemsAndAddToUserParameters();
+                                    // Make an API call for all selected items.
                                     await Wiser.doApiCall(this.base.settings, action.apiConnectionId, mainItemDetails, userParametersWithValues);
                                 }
                             }

--- a/FrontEnd/Modules/DynamicItems/Scripts/Fields.js
+++ b/FrontEnd/Modules/DynamicItems/Scripts/Fields.js
@@ -66,6 +66,7 @@ export class Fields {
             const data = {
                 key: fieldName,
                 itemLinkId: parseInt(fieldData.itemLinkId) || 0,
+                linkType: parseInt(fieldData.linkType) || 0,
                 languageCode: fieldData.languageCode || ""
             };
 


### PR DESCRIPTION
# Describe your changes

Currently, the action of type `apiCall` will run once for all selected items in a grid. The data from the selected items are combined into one field, separated by a comma. Since recently this approach has not become ideal. For that reason, this change has been implemented. This change allows you to flag the API call action by adding the `iterative` attribute. This attribute will change the behaviour of the action by making an API call for each selected item in the grid. The data that is provided to the API call will only be that of the selected item in the current iteration of the loop, rather than all values combined under one key in the `extraData` object.

By default, an API call action will not run iterative, but rather once as the behaviour previously.

## Type of change

Please check only ONE option.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

This was tested by running the `apiCall` action on a single row and multiple rows. It was tested by adding the new `iterative` attribute to the action, and also without to see if the output was expected and both cases were working. This action had a pre- and post-query. Both queries were processed as expected. When adding the `iterative` attribute to the action, the console should log `doApiCall` with the corresponding `extraData` object to the console as many times as the amount of items that are selected from the grid. When the `iterative` attribute is not present and not set to `true`, it will behave as it would previously do. In addition to that, it will only console log `doApiCall` with the `extraData` object once. In this case, the data in the `extraData` object is then combined with all values of the selected items from the grid as it was implemented before.

By adding the possibility to change the behaviour of this action in the form of a flag on the action, it will remain optional. All other actions of this type will behave the same way, meaning this update will not break the functionality of these actions.

# Checklist before requesting a review
- [x] I have reviewed and tested my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [x] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [x] I added new unit tests for my changes if applicable

# Link to Asana ticket

https://app.asana.com/0/0/1207076430837828/f
