### PR TITLE
Fix/escape conditional action button attribute

### DIFF
--- a/FrontEnd/Modules/Base/Scripts/Utils.js
+++ b/FrontEnd/Modules/Base/Scripts/Utils.js
@@ -1681,6 +1681,38 @@ export class Misc {
         // Returning is necessary, since adding new properties to objects is not by reference, but by value.
         return writeRootObject;
     }
+    
+    static encodeHtml(input) {
+        let encodedInput = input.replace(/[<>&]/g, function(match) {
+            switch(match) {
+                case '<': return '&lt;';
+                case '>': return '&gt;';
+                case '&': return '&amp;';
+            }
+        });
+
+        encodedInput = encodedInput.replace(/[\u00A0-\u9999]/g, function(match) {
+            return '&#' + match.charCodeAt(0) + ';';
+        });
+        
+        return encodedInput;
+    }
+    
+    static decodeHtml(input) {
+        let decodedInput = input.replace(/&#\d+;/g, function(match) {
+            return String.fromCharCode(match.match(/\d+/g)[0]);
+        });
+        
+        decodedInput = decodedInput.replace(/(&lt;|&gt;|&ampt;)/g, function(match) {
+            switch(match) {
+                case '&lt;': return '<';
+                case '&gt;': return '>';
+                case '&amp;': return '&';
+            }
+        });
+        
+        return decodedInput;
+    }
 }
 
 // Make the classes globally available, so that they also work in scripts that are not loaded via Webpack.

--- a/FrontEnd/Modules/DynamicItems/Scripts/Grids.js
+++ b/FrontEnd/Modules/DynamicItems/Scripts/Grids.js
@@ -1097,11 +1097,13 @@ export class Grids {
             }
             
             const conditionAttribute = customAction.condition
-                ? `data-condition=${customAction.condition}`
+                ? `data-condition="${Misc.encodeHtml(customAction.condition)}"`
                 : '';
             
             const selector = gridSelector.replace(/#/g, "\\#");
-
+            
+            const { condition, ...customActionData } = customAction;
+            
             if (customAction.groupName) {
                 let group = groups.filter(g => g.name === customAction.groupName)[0];
                 if (!group) {
@@ -1114,12 +1116,12 @@ export class Grids {
                     groups.push(group);
                 }
                 
-                group.actions.push(`<a class='k-button k-button-icontext ${className}' href='\\#' ${conditionAttribute} onclick='return window.dynamicItems.fields.onSubEntitiesGridToolbarActionClick("${selector}", "${encryptedItemId}", "${propertyId}", ${JSON.stringify(customAction)}, event, "${entityType}")' style='${(kendo.htmlEncode(customAction.style || ""))}'><span>${customAction.text}</span></a>`);
+                group.actions.push(`<a class='k-button k-button-icontext ${className}' href='\\#' ${conditionAttribute} onclick='return window.dynamicItems.fields.onSubEntitiesGridToolbarActionClick("${selector}", "${encryptedItemId}", "${propertyId}", ${JSON.stringify(customActionData)}, event, "${entityType}")' style='${(kendo.htmlEncode(customAction.style || ""))}'><span>${customAction.text}</span></a>`);
             } else {
                 actionsWithoutGroups.push({
                     name: `customAction${i.toString()}`,
                     text: customAction.text,
-                    template: `<a class='k-button k-button-icontext ${className}' href='\\#' ${conditionAttribute} onclick='return window.dynamicItems.fields.onSubEntitiesGridToolbarActionClick("${selector}", "${encryptedItemId}", "${propertyId}", ${JSON.stringify(customAction)}, event, "${entityType}")' style='${(kendo.htmlEncode(customAction.style || ""))}'><span class='k-icon k-i-${customAction.icon}'></span>${customAction.text}</a>`
+                    template: `<a class='k-button k-button-icontext ${className}' href='\\#' ${conditionAttribute} onclick='return window.dynamicItems.fields.onSubEntitiesGridToolbarActionClick("${selector}", "${encryptedItemId}", "${propertyId}", ${JSON.stringify(customActionData)}, event, "${entityType}")' style='${(kendo.htmlEncode(customAction.style || ""))}'><span class='k-icon k-i-${customAction.icon}'></span>${customAction.text}</a>`
                 });
             }
         }
@@ -1587,6 +1589,8 @@ export class Grids {
             
             // Conditional check.
             if(condition) {
+                const decodedCondition = Misc.decodeHtml(condition);
+                
                 // Gather field data for each selected row in the grid.
                 const selectedData = [];
                 event.sender.wrapper.find('tr.k-state-selected').each(function() {
@@ -1601,7 +1605,7 @@ export class Grids {
                     const parameterNames = Object.keys(element);
                     const parameterValues = Object.values(element);
 
-                    const func = new Function(...parameterNames, `return ${condition}`);
+                    const func = new Function(...parameterNames, `return ${decodedCondition}`);
                     return func(...parameterValues);
                 });
             }


### PR DESCRIPTION
The condition of conditional buttons were incorrectly escaped when pushing them to an HTML element. This caused the HTML to become "corrupt". The condition is now escaped when pushing it to an HTML element and decoded when retrieving it for evaluating the condition.