### PR TITLE
Nullified title when updating wiser item

### DIFF
--- a/FrontEnd/Modules/DynamicItems/Scripts/Windows.js
+++ b/FrontEnd/Modules/DynamicItems/Scripts/Windows.js
@@ -518,11 +518,8 @@ export class Windows {
             const itemId = data.itemId;
             const inputData = this.base.fields.getInputData(popupWindowContainer.find(".right-pane-content-popup, .dynamicTabContent"));
 
-            let titleToSave = data.title || null;
-            if (titleField.is(":visible")) {
-                titleToSave = newTitle;
-            }
-            const promises = [this.base.updateItem(itemId, inputData, popupWindowContainer, isNewItemWindow, titleToSave, true, true, entityType.entityType || entityType.name)];
+            let titleToSave = newTitle || data.title || null;
+           const promises = [this.base.updateItem(itemId, inputData, popupWindowContainer, isNewItemWindow, titleToSave, true, true, entityType.entityType || entityType.name)];
 
             await Promise.all(promises);
 


### PR DESCRIPTION
# Describe your changes

When the user submits a new wiser item (creating/updating), and any other tab than the default one is selected, the `title` value is `null`. This will result in the wiser item not having a title. This issue occurred due to an incorrect if-statement that checks whether the input field for the title was visible to the user. Since the field's value is always filled when relevant, the if-statement has been discarded from the code.

## Type of change

Please check only ONE option.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

The functionality was once again tested by creating and updating a wiser item by submitting the form while being on another tab than the one with the title's input field. The form's submission now behaves as expected.

# Checklist before requesting a review
- [x] I have reviewed and tested my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [x] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [x] I added new unit tests for my changes if applicable

# Related pull requests

N/A

# Link to Asana ticket

https://app.asana.com/0/0/1207122052075839/f
