### PR TITLE
Customizable create item text and icon

### DIFF
--- a/FrontEnd/Modules/DynamicItems/Scripts/Grids.js
+++ b/FrontEnd/Modules/DynamicItems/Scripts/Grids.js
@@ -325,10 +325,14 @@ export class Grids {
             }
 
             if ((!gridViewSettings.toolbar || !gridViewSettings.toolbar.hideCreateButton) && this.base.settings.permissions.canCreate) {
+                const createButtonSettings = gridViewSettings.toolbar.createButtonSettings;
+                const createButtonText = createButtonSettings?.text || 'Nieuw item toevoegen';
+                const createButtonIcon = createButtonSettings?.icon || 'plus';
+                
                 toolbar.push({
                     name: "add",
                     text: "Nieuw",
-                    template: `<a class='k-button k-button-icontext' href='\\#' onclick='return window.dynamicItems.dialogs.openCreateItemDialog(null, null, null, ${gridViewSettings.skipNameForNewItems})'><span class='k-icon k-i-file-add'></span>Nieuw item toevoegen</a>`
+                    template: `<a class='k-button k-button-icontext' href='\\#' onclick='return window.dynamicItems.dialogs.openCreateItemDialog(null, null, null, ${gridViewSettings.skipNameForNewItems})'><span class='k-icon k-i-${createButtonIcon}'></span>${createButtonText}</a>`
                 });
             }
 


### PR DESCRIPTION
# Describe your changes

This update involves the addition of settings to customize the text and icon of the default create item button in the toolbar of a grid view module. A new setting object for a grid view has been added, called `createButtonSettings`. This object can contain two optional properties, being `text` (to change the text of the button) and `icon` (to change the [Kendo UI icon](https://www.telerik.com/design-system/docs/foundation/iconography/icon-list/) of the button).

Example:
```json
"gridViewSettings": {
   ...
   "createButtonSettings": {
      "text": "Set up new printer",
      "icon": "print"
   }
}
```

This change does not apply to the "Nieuw item toevoegen" button in the pre-defined "Templates" module.

## Type of change

Please check only ONE option.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

This was tested by adjusting the hard-coded text and icon of the button to a configurable value through the provided module settings. If an option is not given, Wiser will revert to a default fallback value.

# Checklist before requesting a review
- [x] I have reviewed and tested my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [x] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [x] I added new unit tests for my changes if applicable

# Related pull requests

N/A

# Link to Asana ticket

https://app.asana.com/0/0/1207122052075845/f
