### PR TITLE
Security fix for global item search

### DIFF
--- a/Api/Modules/Tenants/Models/UserModel.cs
+++ b/Api/Modules/Tenants/Models/UserModel.cs
@@ -141,5 +141,10 @@ namespace Api.Modules.Tenants.Models
         /// This will be used to update the time the user is active.
         /// </summary>
         public string EncryptedLoginLogId { get; set; }
+        
+        /// <summary>
+        /// Gets or sets the indicator telling whether the user is allowed to perform a global search on items.
+        /// </summary>
+        public bool HasSearchPermissions { get; set; }
     }
 }

--- a/FrontEnd/Core/Scripts/main.js
+++ b/FrontEnd/Core/Scripts/main.js
@@ -590,7 +590,10 @@ class Main {
                     // Open Wiser ID prompt when the user presses CTRL+O.
                     if (event.ctrlKey && event.key === "o") {
                         event.preventDefault();
-                        this.openWiserIdPrompt();
+                        
+                        const hasSearchPermissions = this.user.hasSearchPermissions;
+                        if(hasSearchPermissions)
+                            this.openWiserIdPrompt();
                     }
                     // Open MarkerToScreen (Bug reporting) prompt when the user presses CTRL+B.
                     if (event.ctrlKey && event.key === "b") {

--- a/FrontEnd/Core/Scripts/main.js
+++ b/FrontEnd/Core/Scripts/main.js
@@ -209,7 +209,7 @@ class Main {
                 break;
             }
             case "OpenUserData": {
-                const encryptedUserId = await main.itemsService.encryptId(this.vueApp.user.id);
+                const encryptedUserId = this.vueApp.user.encryptedId;
                 this.vueApp.openModule({
                     moduleId: 0,
                     name: "Mijn gegevens",

--- a/FrontEnd/Modules/Configuration/Scripts/Configuration.js
+++ b/FrontEnd/Modules/Configuration/Scripts/Configuration.js
@@ -73,6 +73,7 @@ const moduleSettings = {
             this.settings.userId = userData.encryptedId;
             this.settings.plainUserId = userData.id;
             this.settings.zeroEncrypted = userData.zeroEncrypted;
+            this.settings.hasSearchPermissions = userData.hasSearchPermissions;
             
             await this.toggleModules();
             
@@ -200,6 +201,9 @@ const moduleSettings = {
 
             // Modules that are only available for admins.
             $(`.group-item[data-requires-admin='true']`).toggleClass("hidden", !this.settings.adminAccountLoggedIn);
+            
+            // Hide modules if they require the user to have the global search permissions.
+            $(`.group-item[data-requires-search-permissions='true']`).toggleClass('hidden', !this.settings.hasSearchPermissions);
         }
     }
 

--- a/FrontEnd/Modules/Configuration/Views/Configuration/Index.cshtml
+++ b/FrontEnd/Modules/Configuration/Views/Configuration/Index.cshtml
@@ -170,7 +170,7 @@
                 <span>Zoeken</span>
                 @* <button class="pin-item"><ins class="icon-line-pin-empty"></ins></button> *@
             </a>
-            <a class="group-item" data-action="OpenWiserIdPrompt">
+            <a class="group-item" data-requires-search-permissions="true" data-action="OpenWiserIdPrompt">
                 <ins class="icon-clipboard"></ins>
                 <span>Item openen</span>
                 @* <button class="pin-item"><ins class="icon-line-pin-empty"></ins></button> *@


### PR DESCRIPTION
This pull request implements the security reliability that unauthorized users are not allowed to use the global item search functionality if they do not have access to the "Search" module. This both adds a check in the back end, as well as in the front end.